### PR TITLE
[Issue 10] Do no install or import dotenv in CI

### DIFF
--- a/.github/workflows/delete-old-posts.yml
+++ b/.github/workflows/delete-old-posts.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install -r requirements.txt
+          pip install -e .
       - name: Delete old posts
         run: |
           source .venv/bin/activate

--- a/.github/workflows/delete-old-posts.yml
+++ b/.github/workflows/delete-old-posts.yml
@@ -32,5 +32,4 @@ jobs:
           USERNAME: ${{ vars.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
           DRY_RUN: ${{ vars.DRY_RUN }}
-          # Default is 90 days to present
-          # Use DAYS_AGO to change
+          DAYS_AGO: ${{ vars.DAYS_AGO }}

--- a/.github/workflows/delete-old-reposts.yml
+++ b/.github/workflows/delete-old-reposts.yml
@@ -32,5 +32,4 @@ jobs:
           USERNAME: ${{ vars.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
           DRY_RUN: ${{ vars.DRY_RUN }}
-          # Default is 90 days to present
-          # Use DAYS_AGO to change
+          DAYS_AGO: ${{ vars.DAYS_AGO }}

--- a/.github/workflows/delete-old-reposts.yml
+++ b/.github/workflows/delete-old-reposts.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install -r requirements.txt
+          pip install -e .
       - name: Delete old reposts
         run: |
           source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The goal is to only have posts and reposts that are at most three months old (bu
 2. Check the `.python-version` file for the version of python to use. Other versions might work, but this is the version used during creation.
 3. Create a virtual environment: `python3 -m venv .venv`
 4. Activate the virtual environment: `source .venv/bin/activate`
-5. Install dependencies: `pip install -r requirements.txt`
+5. Install dependencies: `pip install -e .'[dev]'` (for development with dotenv support) or `pip install -e .` (for production)
 6. Get env vars set up: `touch .env & cp .env.sample .env` and change the values in the created `.env`. Note that setting the `DRY_RUN` to false will actually delete things (be careful). Omitting or setting to true will print what will be deleted as a dry run.
 7. Run script: `python delete-posts.py` or `python delete-reposts.py` depending on what you want to do
 

--- a/delete-posts.py
+++ b/delete-posts.py
@@ -2,7 +2,9 @@ import os
 from datetime import datetime, timedelta
 from atproto import Client, exceptions
 
-if not os.getenv("CI"):
+if os.getenv("CI"):
+  print("Running in CI...skipping dotenv import.")
+else:
   from dotenv import load_dotenv
   load_dotenv()
 

--- a/delete-posts.py
+++ b/delete-posts.py
@@ -1,9 +1,10 @@
 import os
 from datetime import datetime, timedelta
-from dotenv import load_dotenv
 from atproto import Client, exceptions
 
-load_dotenv()
+if not os.getenv("CI"):
+  from dotenv import load_dotenv
+  load_dotenv()
 
 # Login
 print("Logging in...⏳")

--- a/delete-reposts.py
+++ b/delete-reposts.py
@@ -2,7 +2,9 @@ import os
 from datetime import datetime, timedelta
 from atproto import Client, exceptions
 
-if not os.getenv("CI"):
+if os.getenv("CI"):
+  print("Running in CI...skipping dotenv import.")
+else:
   from dotenv import load_dotenv
   load_dotenv()
 

--- a/delete-reposts.py
+++ b/delete-reposts.py
@@ -1,9 +1,10 @@
 import os
 from datetime import datetime, timedelta
-from dotenv import load_dotenv
 from atproto import Client, exceptions
 
-load_dotenv()
+if not os.getenv("CI"):
+  from dotenv import load_dotenv
+  load_dotenv()
 
 # Set Variables
 client = Client()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "blueskydelete"
+version = "0.1.0"
+authors = [
+  {name = "Danielle Heberling"}
+]
+dependencies = [
+  "atproto==0.0.61"
+]
+
+[project.optional-dependencies]
+dev = ["python-dotenv==1.1.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-atproto==0.0.61
-python-dotenv==1.1.1


### PR DESCRIPTION
### Changes

- move from `requirements.txt` to `pyproject.toml`
- only install, import, and load dotenv if not in CI
- update docs

fixes #10 